### PR TITLE
Added opencl disable to x264 linux with note

### DIFF
--- a/src/native/ffmpeg/README
+++ b/src/native/ffmpeg/README
@@ -76,7 +76,9 @@ patch -Np1 -i x264-01-freebsd.patch
 
 - Linux, Mac OS X
 
-./configure --enable-pic
+./configure --enable-pic --disable-opencl
+
+Without the opencl option, ffmpeg configure may fail with (ERROR: libx264 not found).
 
 - For android
 NDK_BASE=/../android-ndk-r8c


### PR DESCRIPTION
Without added the disable for opencl when configuring x264, the ffmpeg configure can fail