### PR TITLE
FFmpeg: Compile with release 4.x.

### DIFF
--- a/src/main/c/ffmpeg/FFmpeg.c
+++ b/src/main/c/ffmpeg/FFmpeg.c
@@ -565,11 +565,11 @@ Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1quantizer
 
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(rc_1buffer_1size, rc_buffer_size)
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
 JNIEXPORT void JNICALL
 Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
     (JNIEnv *env, jclass clazz, jlong ctx, jstring rc_eq)
 {
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
     char *s;
 
     if (rc_eq)
@@ -591,8 +591,8 @@ Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
         s = NULL;
     }
     ((AVCodecContext *) (intptr_t) ctx)->rc_eq = s;
-#endif
 }
+#endif
 
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(rc_1max_1rate, rc_max_rate)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(refs, refs)

--- a/src/main/c/ffmpeg/FFmpeg.c
+++ b/src/main/c/ffmpeg/FFmpeg.c
@@ -541,9 +541,6 @@ DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(keyint_1min, keyint_min)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(max_1b_1frames, max_b_frames)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(mb_1decision, mb_decision)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1cmp, me_cmp)
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
-DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1method, me_method)
-#endif
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1range, me_range)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1subpel_1quality, me_subpel_quality)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(pix_1fmt, pix_fmt)
@@ -564,36 +561,6 @@ Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1quantizer
 }
 
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(rc_1buffer_1size, rc_buffer_size)
-
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
-JNIEXPORT void JNICALL
-Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
-    (JNIEnv *env, jclass clazz, jlong ctx, jstring rc_eq)
-{
-    char *s;
-
-    if (rc_eq)
-    {
-        const char *js = (*env)->GetStringUTFChars(env, rc_eq, NULL);
-
-        if (js)
-        {
-            s = av_strdup(js);
-            (*env)->ReleaseStringUTFChars(env, rc_eq, js);
-        }
-        else
-        {
-            s = NULL;
-        }
-    }
-    else
-    {
-        s = NULL;
-    }
-    ((AVCodecContext *) (intptr_t) ctx)->rc_eq = s;
-}
-#endif
-
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(rc_1max_1rate, rc_max_rate)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(refs, refs)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(rtp_1payload_1size, rtp_payload_size)

--- a/src/main/c/ffmpeg/FFmpeg.c
+++ b/src/main/c/ffmpeg/FFmpeg.c
@@ -15,7 +15,9 @@
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,8,0)
 #include <libavfilter/avfiltergraph.h>
+#endif
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libswscale/swscale.h>
@@ -539,7 +541,9 @@ DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(keyint_1min, keyint_min)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(max_1b_1frames, max_b_frames)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(mb_1decision, mb_decision)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1cmp, me_cmp)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1method, me_method)
+#endif
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1range, me_range)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(me_1subpel_1quality, me_subpel_quality)
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(pix_1fmt, pix_fmt)
@@ -565,6 +569,7 @@ JNIEXPORT void JNICALL
 Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
     (JNIEnv *env, jclass clazz, jlong ctx, jstring rc_eq)
 {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
     char *s;
 
     if (rc_eq)
@@ -586,6 +591,7 @@ Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
         s = NULL;
     }
     ((AVCodecContext *) (intptr_t) ctx)->rc_eq = s;
+#endif
 }
 
 DEFINE_AVCODECCONTEXT_I_PROPERTY_SETTER(rc_1max_1rate, rc_max_rate)

--- a/src/main/c/ffmpeg/FFmpeg.h
+++ b/src/main/c/ffmpeg/FFmpeg.h
@@ -301,7 +301,7 @@ JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_
  */
 JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1me_1cmp
   (JNIEnv *, jclass, jlong, jint);
-
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
 /*
  * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
  * Method:    avcodeccontext_set_me_method
@@ -309,7 +309,7 @@ JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_
  */
 JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1me_1method
   (JNIEnv *, jclass, jlong, jint);
-
+#endif
 /*
  * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
  * Method:    avcodeccontext_set_me_range
@@ -365,7 +365,7 @@ JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_
  */
 JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1buffer_1size
   (JNIEnv *, jclass, jlong, jint);
-
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
 /*
  * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
  * Method:    avcodeccontext_set_rc_eq
@@ -373,7 +373,7 @@ JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_
  */
 JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
   (JNIEnv *, jclass, jlong, jstring);
-
+#endif
 /*
  * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
  * Method:    avcodeccontext_set_rc_max_rate

--- a/src/main/c/ffmpeg/FFmpeg.h
+++ b/src/main/c/ffmpeg/FFmpeg.h
@@ -301,15 +301,7 @@ JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_
  */
 JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1me_1cmp
   (JNIEnv *, jclass, jlong, jint);
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
-/*
- * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
- * Method:    avcodeccontext_set_me_method
- * Signature: (JI)V
- */
-JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1me_1method
-  (JNIEnv *, jclass, jlong, jint);
-#endif
+
 /*
  * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
  * Method:    avcodeccontext_set_me_range
@@ -365,15 +357,7 @@ JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_
  */
 JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1buffer_1size
   (JNIEnv *, jclass, jlong, jint);
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,0,0)
-/*
- * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
- * Method:    avcodeccontext_set_rc_eq
- * Signature: (JLjava/lang/String;)V
- */
-JNIEXPORT void JNICALL Java_org_jitsi_impl_neomedia_codec_FFmpeg_avcodeccontext_1set_1rc_1eq
-  (JNIEnv *, jclass, jlong, jstring);
-#endif
+
 /*
  * Class:     org_jitsi_impl_neomedia_codec_FFmpeg
  * Method:    avcodeccontext_set_rc_max_rate

--- a/src/main/java/org/jitsi/impl/neomedia/codec/FFmpeg.java
+++ b/src/main/java/org/jitsi/impl/neomedia/codec/FFmpeg.java
@@ -84,22 +84,22 @@ public class FFmpeg
     /**
      * H263 codec ID.
      */
-    public static final int CODEC_ID_H263 = 5;
+    public static final int CODEC_ID_H263 = 4;
 
     /**
      * H263+ codec ID.
      */
-    public static final int CODEC_ID_H263P = 20;
+    public static final int CODEC_ID_H263P = 19;
 
     /**
      * H264 codec ID.
      */
-    public static final int CODEC_ID_H264 = 28;
+    public static final int CODEC_ID_H264 = 27;
 
     /**
      * MJPEG codec ID.
      */
-    public static final int CODEC_ID_MJPEG = 8;
+    public static final int CODEC_ID_MJPEG = 7;
 
     /**
      * MP3 codec ID.
@@ -109,7 +109,7 @@ public class FFmpeg
     /**
      * VP8 codec ID
      */
-    public static final int CODEC_ID_VP8 = 142;
+    public static final int CODEC_ID_VP8 = 139;
 
     /**
      * Work around bugs in encoders which sometimes cannot be detected


### PR DESCRIPTION
required, because of the following commits in libAV:

- [38f0c0781a6e099f11c0acec07f9b8be742190c4](https://code.videolan.org/libav/libav/commit/38f0c0781a6e099f11c0acec07f9b8be742190c4)  
- [4b6b1082a73907c7c3de2646c6398bc61320f2c6](https://code.videolan.org/libav/libav/commit/4b6b1082a73907c7c3de2646c6398bc61320f2c6)
- [a75c2eb25a62105c09b48521aef429dc8a231637](https://code.videolan.org/libav/libav/commit/a75c2eb25a62105c09b48521aef429dc8a231637)
- [94eed68ace9f2416af8457fcbf142b175928c06b](https://code.videolan.org/libav/libav/commit/94eed68ace9f2416af8457fcbf142b175928c06b)