### PR TITLE
FFmpeg: Re-enable automatic conversions in filter graphs like hflip.

### DIFF
--- a/src/main/c/ffmpeg/FFmpeg.c
+++ b/src/main/c/ffmpeg/FFmpeg.c
@@ -20,13 +20,6 @@
 #include <libavfilter/buffersrc.h>
 #include <libswscale/swscale.h>
 
-// for libavfilter5
-#ifndef AVFILTER_AUTO_CONVERT_NONE
-enum {
-    AVFILTER_AUTO_CONVERT_NONE = -1 /**< all automatic conversions disabled */
-};
-#endif
-
 // libavutil54
 #ifndef AV_ERROR_MAX_STRING_SIZE
 #define AV_ERROR_MAX_STRING_SIZE 64
@@ -637,12 +630,7 @@ JNIEXPORT jlong JNICALL
 Java_org_jitsi_impl_neomedia_codec_FFmpeg_avfilter_1graph_1alloc
     (JNIEnv *env, jclass clazz)
 {
-    AVFilterGraph* graph = avfilter_graph_alloc();
-    if (graph) {
-        avfilter_graph_set_auto_convert(graph, AVFILTER_AUTO_CONVERT_NONE );
-    }
-
-    return (jlong) (intptr_t) graph;
+    return (jlong) (intptr_t) avfilter_graph_alloc();
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
This undos a slipped-through part of commit d8338bc.

close #9