### PR TITLE
Bumps the version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.jitsi</groupId>
   <artifactId>jitsi-lgpl-dependencies</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>jitsi-lgpl-dependencies</name>


### PR DESCRIPTION
Bumps the version after moving libs from timestamped snapshots to
released with git describe version.