### PR TITLE
Update jitsi-utils and don't import a specific OSGi service version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
                 win32-x86-64/jnffmpeg.dll;osname=Win32;processor=x86-64,
                 win32-x86-64/jnffmpeg-no-openh264.dll;osname=Win32;processor=x86-64
                </Bundle-NativeCode>
+              <!-- Prevent importing a specific version. -->
+              <Import-Package>*;version=!</Import-Package>
             </instructions>
          </configuration>
       </plugin>
@@ -164,7 +166,7 @@
     <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jitsi-utils</artifactId>
-        <version>v1.0-66-g9f2339f</version>
+        <version>1.0-67-g4032ab6</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The wrong v-prefix in -utils causes an import of service version [0,1),
which is not there as -utils exports no service versions and the
lib-version is 1.0-x.